### PR TITLE
QRコードのリンク先がPDFファイルになる

### DIFF
--- a/app/controllers/palmistry_controller.rb
+++ b/app/controllers/palmistry_controller.rb
@@ -5,7 +5,8 @@ class PalmistryController < ApplicationController
   end
 
   def show
-    @qr_url = RQRCode::QRCode.new(request.url).to_img.resize(300, 300).to_data_url
+    url_without_pdf = request.url.gsub(/\.pdf\Z/,'')
+    @qr_url = RQRCode::QRCode.new(url_without_pdf).to_img.resize(300, 300).to_data_url
 
     user = User.find_by(access_token: params[:access_token]) if params[:access_token]
     @uname = user.uname


### PR DESCRIPTION
## 問題
- QRコードのリンク先がPDFファイルになる
- Webの結果の方にアクセスして欲しい

## 原因
- QRコードのリンク先が現在表示しているリンクになっている

## 対応
- QRコードのURLに .pdf の文字を削除した